### PR TITLE
Improve JSONSchema types

### DIFF
--- a/src/interfaces/JsonSchema.ts
+++ b/src/interfaces/JsonSchema.ts
@@ -17,6 +17,8 @@ interface PrimitiveType<U> {
  */
 interface RootSchema {
   $schema?: string
+  $ref?: string
+  definitions?: string
 }
 
 /**
@@ -77,7 +79,8 @@ interface BaseNumberSchema<U> extends GenericType, PrimitiveType<U> {
   exclusiveMaximum?: number
   exclusiveMinimum?: number
   minimum?: number
-  maximum?: number
+  maximum?: number,
+  enum?: number[]
 }
 
 /**

--- a/src/interfaces/JsonSchema.ts
+++ b/src/interfaces/JsonSchema.ts
@@ -32,6 +32,7 @@ interface GenericType extends CombinationOperators<JSONSchema> {
   const?: any
   contentEncoding?: string
   contentMediaType?: string
+  enum?: (number | string | Object | Array<any> | boolean | null)[]
 }
 
 /**
@@ -79,8 +80,7 @@ interface BaseNumberSchema<U> extends GenericType, PrimitiveType<U> {
   exclusiveMaximum?: number
   exclusiveMinimum?: number
   minimum?: number
-  maximum?: number,
-  enum?: number[]
+  maximum?: number
 }
 
 /**


### PR DESCRIPTION
Changes:
- Add `$ref?` and `definitions?` to `RootSchema` interface to allow for ref-based schemas
- Add `enum?` property to `GenericType`, since it is specified on JSON Schema's [Generic Keywords](https://cswr.github.io/JsonSchema/spec/generic_keywords/#enumerated-values)